### PR TITLE
chore: prefer CIRCLE_SHA1 vs CIRCLE_TAG in circle's cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,12 @@ commands:
     steps:
       - restore_cache:
           name: Restore sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
   save-sccache-cache:
     steps:
       - save_cache:
           name: Save sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
+          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
 jobs:
@@ -137,7 +137,7 @@ jobs:
             mkdir -p /home/circleci/cache
             docker save -o /home/circleci/cache/docker.tar "app:build"
       - save_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}-{{ epoch }}
           paths:
             - /home/circleci/cache
 
@@ -150,7 +150,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar


### PR DESCRIPTION
per https://github.com/mozilla-services/Dockerflow/pull/44

_TAG seems to only fix this issue on tagged builds, whereas _SHA1 should also
solve it on dev builds lacking a tag

and switch the currently unused sccache key to CIRCLE_JOB

## Description

Describe these changes.

## Testing

How should reviewers test?

## Issue(s)

Closes [link](link).
